### PR TITLE
Add mr-audit multi-model merge request review skill

### DIFF
--- a/claude/skills/mr-audit/SKILL.md
+++ b/claude/skills/mr-audit/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   confidence-tiered report. Use when you want a thorough multi-perspective merge request review.
 argument-hint: [mr-number] [jira-ticket]
 disable-model-invocation: true
-allowed-tools: Bash(codex exec *), Bash(which *), Bash(glab mr view *), Bash(glab mr diff *), Bash(glab mr list *), Bash(git branch *), Bash(git log *), Bash(git diff *), Bash(jj log *), Bash(jj show *), Bash(jq *), Read, Grep, Glob, Skill(mr-review *), Skill(jira *)
+allowed-tools: Bash(codex exec *), Bash(which *), Bash(glab mr view *), Bash(glab mr diff *), Bash(glab mr list *), Bash(git log *), Bash(git diff *), Bash(jj log *), Bash(jj show *), Bash(jq *), Read, Grep, Glob, Skill(mr-review *), Skill(jira *)
 metadata:
   compatibility: Requires codex CLI (npm i -g @openai/codex), glab CLI, and Codex skills (jira, mr-review) in ~/.codex/skills/. See references/SETUP.md. Degrades gracefully to Claude-only if Codex is unavailable.
 ---
@@ -15,10 +15,12 @@ metadata:
 
 Run three independent reviews in parallel — Claude Code (`/mr-review`), Codex skill-based (`$mr-review`), and Codex built-in code review — then cross-validate findings against the codebase and compile a single confidence-tiered report.
 
+> **Critical rule**: Every Bash command must be a standalone call. NEVER combine commands with `||`, `&&`, `|`, or `;`. Handle errors and fallbacks in skill logic — run one command, check its output, then decide what to do next. Compound commands break the permission system and will trigger approval prompts.
+
 ## Pre-flight
 
 - Codex installed: !`which codex 2>/dev/null || echo "NOT_FOUND"`
-- Current branch: !`git branch --show-current`
+- Current bookmark: !`jj log -r 'ancestors(@) & bookmarks()' --limit 1 --no-graph -T 'bookmarks.join(", ")' 2>/dev/null`
 - Working directory: !`pwd`
 - JJ status: !`jj log -r @ --no-graph -T 'self.change_id().shortest(8) ++ " " ++ branches' 2>/dev/null || echo "NO_JJ"`
 - MR info: !`glab mr view 2>/dev/null || echo "NO_MR"`
@@ -39,22 +41,34 @@ All three reviews need the same MR and Jira ticket. Resolve both upfront so ever
 Use this priority:
 1. $ARGUMENTS[0] if provided — use as MR number or branch name
 2. Pre-flight MR info — if it found an MR for the current branch, use that
-3. **If neither works**: Run `glab mr list` (lists open MRs by default) and present the list to the user to pick from
+3. **If neither works**: Run `glab mr list -P 10` (lists open MRs by default, limited to 10) and present the list to the user to pick from
 4. If no open MRs exist — abort, nothing to review
 
 **Important**: `glab mr list` has no `--state` flag — see [references/glab-flags.md](references/glab-flags.md) for correct flags.
 
 ### 0.2 Fetch MR Details
 
-Once the MR is determined, run `glab mr view {MR_NUMBER}` (if not already in pre-flight) to get the full title, description, author, source branch, and target branch.
+Run this exact command:
+
+    glab mr view {MR_NUMBER} -F json
+
+Parse these fields from the JSON output:
+- `source_branch` — the MR's source branch
+- `target_branch` — the MR's target branch
+- `title` — MR title
+- `description` — MR description
+- `author.username` — MR author
+
+Do NOT use `glab api`, pipes, or any other command to get this information.
 
 ### 0.3 Verify Working Copy
 
 All three reviews read files from the local working tree. If the checkout doesn't match the MR source branch, reviews will analyze wrong code.
 
-1. Compare the MR **source branch** (from 0.2) with the current branch (from pre-flight)
-2. If using jj (pre-flight JJ status is not `NO_JJ`): check that the current jj revision is on or descends from the MR source branch. Use `jj log` to verify.
-3. **If mismatched**: Warn the user that their working copy is on a different branch and ask whether to proceed anyway or switch first. Do NOT switch automatically — the user may have uncommitted work.
+1. Get the current bookmark from pre-flight
+2. Compare it with the MR `source_branch` (from Phase 0.2)
+3. If they match — working copy is correct
+4. If they don't match or pre-flight returned empty — warn the user and ask whether to proceed or switch first. Do NOT switch automatically.
 
 ### 0.4 Extract Jira Ticket
 
@@ -72,7 +86,9 @@ If pre-flight shows `NOT_FOUND`, set mode to **Claude-Only** and skip to Phase 1
 
 Derive the project name from the last segment of the working directory path (pre-flight). Use it for uniqueness across parallel runs:
 - Codex skill review: `/tmp/codex-mr-review-{PROJECT}-{MR_NUMBER}.md`
-- Codex built-in raw: `/tmp/codex-builtin-raw-{PROJECT}-{MR_NUMBER}.jsonl`
+- Codex built-in raw JSONL: `/tmp/codex-builtin-raw-{PROJECT}-{MR_NUMBER}.jsonl`
+
+The Codex built-in review text is extracted from the JSONL via `jq` at processing time — no separate file needed.
 - Codex built-in review: `/tmp/codex-builtin-review-{PROJECT}-{MR_NUMBER}.md`
 
 ---
@@ -106,10 +122,12 @@ codex exec review --base {TARGET_BRANCH} --full-auto --json > "/tmp/codex-builti
 **Step 2** — extract the review text (after background task completes):
 
 ```bash
-jq -rs '[.[] | select(.type=="item.completed" and .item.type=="agent_message") | .item.text] | last // ""' "/tmp/codex-builtin-raw-{PROJECT}-{MR_NUMBER}.jsonl" > "/tmp/codex-builtin-review-{PROJECT}-{MR_NUMBER}.md"
+jq -rs '[.[] | select(.type=="item.completed" and .item.type=="agent_message") | .item.text] | last // ""' "/tmp/codex-builtin-raw-{PROJECT}-{MR_NUMBER}.jsonl"
 ```
 
-**Note**: The pipe is split into two steps because Claude Code's Bash tool breaks pipe operators — see [references/codex-review-bug.md](references/codex-review-bug.md) for why `--json` + `jq` is needed instead of `-o`.
+The review text is returned as Bash output — do NOT redirect to a file with `>` (redirects are shell operators that break permission auto-approval). Hold the output for use in Phase 3.
+
+**Note**: These are two separate Bash calls, not a pipe. See the global rule about standalone commands. See [references/codex-review-bug.md](references/codex-review-bug.md) for why `--json` + `jq` is needed instead of `-o`.
 
 ### 1C: Claude Review (foreground)
 
@@ -127,13 +145,26 @@ If no ticket was found, omit it: `/mr-review {MR_NUMBER}`
 
 After `/mr-review` finishes:
 
-1. Check if both Codex background tasks have completed
-2. If either is still running, wait for completion
-3. Run the Phase 1B Step 2 `jq` extraction on the raw JSONL file to produce the final review file
-4. Read both output files:
-   - `/tmp/codex-mr-review-{PROJECT}-{MR_NUMBER}.md`
-   - `/tmp/codex-builtin-review-{PROJECT}-{MR_NUMBER}.md`
-5. **Degrade gracefully** per source:
+### Waiting for background tasks
+
+Use `TaskOutput` with `block=true` to wait. It long-polls — returns instantly when the task completes, or after the timeout if still running. It does NOT sleep for the full timeout.
+
+For each background task:
+1. Call `TaskOutput(task_id, block=true, timeout=600000)` — waits up to 10 min
+2. If the task is still running, call `TaskOutput` again (another 10 min)
+3. Repeat up to 3 times total (30 min maximum)
+4. After 30 min: stop the task with `TaskStop`, skip that source, degrade gracefully
+
+Do NOT stop background tasks before the 30-minute limit. Codex reviews can legitimately take 15-20 minutes on large MRs.
+
+**Fallback**: If `TaskOutput` behaves unexpectedly (hangs, returns no data), check the output files directly with Read. A non-empty output file may indicate completion even if TaskOutput didn't report it.
+
+### Processing results
+
+1. Run the Phase 1B Step 2 `jq` command on the raw JSONL file — the review text comes back as Bash output
+2. Read the Codex skill review file: `/tmp/codex-mr-review-{PROJECT}-{MR_NUMBER}.md`
+3. You now have all three reviews: Claude (from Phase 1C), Codex skill (from the file), Codex built-in (from jq output)
+4. **Degrade gracefully** per source:
    - If a file is missing, empty, or contains error output → exclude that source
    - Note which sources are available for the final report
    - If both Codex sources failed → Claude-Only mode
@@ -205,23 +236,6 @@ If Codex was unavailable or both Codex sources failed:
 - Omit consensus tags, omit Dismissed section
 - Add a note at the top: "**Mode: Claude-Only** — {reason}"
 - Use Claude review findings directly, organized by severity
-
----
-
-## Phase 5: Preserve & Fork
-
-After the report is output, preserve this session as a review reference and offer to fork for follow-up work.
-
-1. Run `/rename` with a descriptive name:
-   ```
-   /rename REVIEW {TICKET} MR!{MR_NUMBER} {short MR title}
-   ```
-   Example: `/rename REVIEW STB-1417 MR!3 Fix InstallDeviceOpenError`
-
-2. Tell the user the session has been renamed, then suggest:
-   ```
-   Run /fork to start a new session with this review as context.
-   ```
 
 ---
 

--- a/claude/skills/mr-audit/SKILL.md
+++ b/claude/skills/mr-audit/SKILL.md
@@ -17,6 +17,8 @@ Run three independent reviews in parallel — Claude Code (`/mr-review`), Codex 
 
 > **Critical rule**: Every Bash command must be a standalone call. NEVER combine commands with `||`, `&&`, `|`, or `;`. Handle errors and fallbacks in skill logic — run one command, check its output, then decide what to do next. Compound commands break the permission system and will trigger approval prompts.
 
+> **Language rule**: The entire report must be written in English. All findings, explanations, suggestions, architecture assessments, and questions must be in English. The only exception is direct quotes from source materials (reviewer comments, MR descriptions, Jira tickets) — these may remain in their original language when explicitly quoted.
+
 ## Pre-flight
 
 - Codex installed: !`which codex 2>/dev/null || echo "NOT_FOUND"`
@@ -225,10 +227,11 @@ Combine architecture and testing opinions from all available sources into unifie
 
 1. Load the report template from [references/report-format.md](references/report-format.md)
 2. Fill in all sections following the template and its filling instructions
-3. Group findings by severity: Must Fix → Should Fix → Nit
-4. Within each group, order by priority (highest impact first)
-5. Each finding: `[tag] **summary**` / `file:lines` on separate lines / merged explanation / `→ suggestion`
-6. Include file:line references on every finding
+3. Write everything in English (see Language rule above — only direct quotes may stay in original language)
+4. Group findings by severity: Must Fix → Should Fix → Nit
+5. Within each group, order by priority (highest impact first)
+6. Each finding: `[tag] **summary**` / `file:lines` on separate lines / merged explanation / `→ suggestion`
+7. Include file:line references on every finding
 
 ### Claude-Only Mode
 

--- a/claude/skills/mr-audit/SKILL.md
+++ b/claude/skills/mr-audit/SKILL.md
@@ -1,0 +1,248 @@
+---
+name: mr-audit
+description: >-
+  Triple-model MR review that runs Claude Code, Codex skill-based, and Codex built-in reviews
+  in parallel, cross-validates findings against the codebase, and produces a unified
+  confidence-tiered report. Use when you want a thorough multi-perspective merge request review.
+argument-hint: [mr-number] [jira-ticket]
+disable-model-invocation: true
+allowed-tools: Bash(codex exec *), Bash(which *), Bash(glab mr view *), Bash(glab mr diff *), Bash(glab mr list *), Bash(git branch *), Bash(git log *), Bash(git diff *), Bash(jj log *), Bash(jj show *), Bash(jq *), Read, Grep, Glob, Skill(mr-review *), Skill(jira *)
+metadata:
+  compatibility: Requires codex CLI (npm i -g @openai/codex), glab CLI, and Codex skills (jira, mr-review) in ~/.codex/skills/. See references/SETUP.md. Degrades gracefully to Claude-only if Codex is unavailable.
+---
+
+# Triple-Model MR Review
+
+Run three independent reviews in parallel — Claude Code (`/mr-review`), Codex skill-based (`$mr-review`), and Codex built-in code review — then cross-validate findings against the codebase and compile a single confidence-tiered report.
+
+## Pre-flight
+
+- Codex installed: !`which codex 2>/dev/null || echo "NOT_FOUND"`
+- Current branch: !`git branch --show-current`
+- Working directory: !`pwd`
+- JJ status: !`jj log -r @ --no-graph -T 'self.change_id().shortest(8) ++ " " ++ branches' 2>/dev/null || echo "NO_JJ"`
+- MR info: !`glab mr view 2>/dev/null || echo "NO_MR"`
+
+## Arguments
+
+- **MR Identifier**: $ARGUMENTS[0] (MR number, branch name, or empty for current branch)
+- **Jira Ticket**: $ARGUMENTS[1] (optional — key like STB-1417 or URL)
+
+---
+
+## Phase 0: Resolve MR & Jira Context
+
+All three reviews need the same MR and Jira ticket. Resolve both upfront so every review gets consistent input.
+
+### 0.1 Determine MR
+
+Use this priority:
+1. $ARGUMENTS[0] if provided — use as MR number or branch name
+2. Pre-flight MR info — if it found an MR for the current branch, use that
+3. **If neither works**: Run `glab mr list` (lists open MRs by default) and present the list to the user to pick from
+4. If no open MRs exist — abort, nothing to review
+
+**Important**: `glab mr list` has no `--state` flag — see [references/glab-flags.md](references/glab-flags.md) for correct flags.
+
+### 0.2 Fetch MR Details
+
+Once the MR is determined, run `glab mr view {MR_NUMBER}` (if not already in pre-flight) to get the full title, description, author, source branch, and target branch.
+
+### 0.3 Verify Working Copy
+
+All three reviews read files from the local working tree. If the checkout doesn't match the MR source branch, reviews will analyze wrong code.
+
+1. Compare the MR **source branch** (from 0.2) with the current branch (from pre-flight)
+2. If using jj (pre-flight JJ status is not `NO_JJ`): check that the current jj revision is on or descends from the MR source branch. Use `jj log` to verify.
+3. **If mismatched**: Warn the user that their working copy is on a different branch and ask whether to proceed anyway or switch first. Do NOT switch automatically — the user may have uncommitted work.
+
+### 0.4 Extract Jira Ticket
+
+Use this priority:
+1. $ARGUMENTS[1] if provided
+2. Extract from MR title (pattern: `[A-Z]+-\d+`, e.g. "STB-1417 [OTAUpdater]..." or "STB-1343: Доработка...")
+3. Extract from MR description or branch name
+4. **Ask the user** for the Jira ticket key or URL — it is acceptable if the user has no ticket, proceed without
+
+### 0.5 Check Codex
+
+If pre-flight shows `NOT_FOUND`, set mode to **Claude-Only** and skip to Phase 1C. Refer user to [references/SETUP.md](references/SETUP.md) for installation.
+
+### 0.6 Build Output Paths
+
+Derive the project name from the last segment of the working directory path (pre-flight). Use it for uniqueness across parallel runs:
+- Codex skill review: `/tmp/codex-mr-review-{PROJECT}-{MR_NUMBER}.md`
+- Codex built-in raw: `/tmp/codex-builtin-raw-{PROJECT}-{MR_NUMBER}.jsonl`
+- Codex built-in review: `/tmp/codex-builtin-review-{PROJECT}-{MR_NUMBER}.md`
+
+---
+
+## Phase 1: Launch Three Parallel Reviews
+
+Launch all three simultaneously. Make 1A and 1B as background Bash calls, then invoke 1C as a foreground skill.
+
+### 1A: Codex Skill Review (background)
+
+Run with `run_in_background=true`. This uses the `$mr-review` Codex skill which mirrors Claude's structured review with glab and Jira context.
+
+```bash
+codex exec -s danger-full-access -C "$PWD" \
+  -o "/tmp/codex-mr-review-{PROJECT}-{MR_NUMBER}.md" \
+  '$mr-review {MR_NUMBER}'
+```
+
+**Important**: Do NOT use `--full-auto` — it overrides sandbox to workspace-write, blocking network access needed for `glab` and Jira.
+
+### 1B: Codex Built-in Code Review (background)
+
+Run with `run_in_background=true`. This is Codex's own review engine — pure code diff analysis without MR/Jira context. A different angle.
+
+**Step 1** — capture raw JSONL output (background):
+
+```bash
+codex exec review --base {TARGET_BRANCH} --full-auto --json > "/tmp/codex-builtin-raw-{PROJECT}-{MR_NUMBER}.jsonl"
+```
+
+**Step 2** — extract the review text (after background task completes):
+
+```bash
+jq -rs '[.[] | select(.type=="item.completed" and .item.type=="agent_message") | .item.text] | last // ""' "/tmp/codex-builtin-raw-{PROJECT}-{MR_NUMBER}.jsonl" > "/tmp/codex-builtin-review-{PROJECT}-{MR_NUMBER}.md"
+```
+
+**Note**: The pipe is split into two steps because Claude Code's Bash tool breaks pipe operators — see [references/codex-review-bug.md](references/codex-review-bug.md) for why `--json` + `jq` is needed instead of `-o`.
+
+### 1C: Claude Review (foreground)
+
+Invoke the existing skill with both MR and ticket (already resolved in Phase 0):
+
+```
+/mr-review {MR_NUMBER} {JIRA_TICKET}
+```
+
+If no ticket was found, omit it: `/mr-review {MR_NUMBER}`
+
+---
+
+## Phase 2: Collect Results
+
+After `/mr-review` finishes:
+
+1. Check if both Codex background tasks have completed
+2. If either is still running, wait for completion
+3. Run the Phase 1B Step 2 `jq` extraction on the raw JSONL file to produce the final review file
+4. Read both output files:
+   - `/tmp/codex-mr-review-{PROJECT}-{MR_NUMBER}.md`
+   - `/tmp/codex-builtin-review-{PROJECT}-{MR_NUMBER}.md`
+5. **Degrade gracefully** per source:
+   - If a file is missing, empty, or contains error output → exclude that source
+   - Note which sources are available for the final report
+   - If both Codex sources failed → Claude-Only mode
+
+---
+
+## Phase 3: Cross-Validate & Investigate
+
+This is the core value. Three independent models give three perspectives — overlapping findings have highest confidence.
+
+### 3.1 Classify Findings
+
+For each finding, assign two things:
+
+**Consensus tag** — how many sources flagged it:
+
+| Tag | Meaning |
+|-----|---------|
+| `[all]` | All available sources agree |
+| `[2/3]` | Two of three sources agree |
+| `[confirmed]` | Single source, verified by code investigation |
+| `[uncertain]` | Single source, could not confirm or dismiss |
+
+**Severity** — how bad it is:
+
+| Severity | Use for |
+|----------|---------|
+| **Must Fix** | Bugs, missing safety nets, production breakage |
+| **Should Fix** | Code quality, duplication, maintainability |
+| **Nit** | Style, naming, minor inconsistencies |
+
+Match findings by: same file + same function/area + same type of issue. Similar issues in the same area count as agreement even if wording differs.
+
+For severity conflicts on the same finding: default to the **higher** severity.
+
+### 3.2 Investigate Single-Source Findings
+
+For each finding raised by only one model:
+
+1. **Read the code** at the referenced file:line with surrounding context
+2. **Search for related patterns** — callers, similar code, existing tests
+3. **Assign a verdict**:
+   - **Confirmed** — code investigation supports the finding
+   - **Dismissed** — the code is actually correct; explain why (e.g. "handled by caller", "tested in FooTest.kt")
+   - **Uncertain** — cannot definitively confirm or dismiss; flag for human review
+
+### 3.3 Merge Explanations
+
+For each finding, combine insights from all sources that flagged it into **one unified explanation**. Do not list per-model assessments — write one coherent description with the best insights from each source.
+
+### 3.4 Merge Architecture & Testing Assessments
+
+Combine architecture and testing opinions from all available sources into unified assessments. Note where sources agree or diverge.
+
+---
+
+## Phase 4: Compile Unified Report
+
+1. Load the report template from [references/report-format.md](references/report-format.md)
+2. Fill in all sections following the template and its filling instructions
+3. Group findings by severity: Must Fix → Should Fix → Nit
+4. Within each group, order by priority (highest impact first)
+5. Each finding: `[tag] **summary**` / `file:lines` on separate lines / merged explanation / `→ suggestion`
+6. Include file:line references on every finding
+
+### Claude-Only Mode
+
+If Codex was unavailable or both Codex sources failed:
+- Omit consensus tags, omit Dismissed section
+- Add a note at the top: "**Mode: Claude-Only** — {reason}"
+- Use Claude review findings directly, organized by severity
+
+---
+
+## Phase 5: Preserve & Fork
+
+After the report is output, preserve this session as a review reference and offer to fork for follow-up work.
+
+1. Run `/rename` with a descriptive name:
+   ```
+   /rename REVIEW {TICKET} MR!{MR_NUMBER} {short MR title}
+   ```
+   Example: `/rename REVIEW STB-1417 MR!3 Fix InstallDeviceOpenError`
+
+2. Tell the user the session has been renamed, then suggest:
+   ```
+   Run /fork to start a new session with this review as context.
+   ```
+
+---
+
+## Error Handling
+
+| Scenario | Response |
+|----------|----------|
+| Codex not installed | Claude-Only mode; refer to [references/SETUP.md](references/SETUP.md) |
+| Codex skill review failed | Exclude that source, note reason |
+| Codex built-in review failed | Exclude that source, note reason |
+| Both Codex sources failed | Claude-Only mode |
+| Working copy on wrong branch | Warn user, ask to proceed or switch first |
+| MR not found | Abort with clear message |
+| No Jira ticket | Proceed without (same as /mr-review) |
+
+---
+
+## Usage
+
+```bash
+/mr-audit 43 STB-1417      # MR number + Jira ticket
+/mr-audit 43                # MR number, Jira auto-extracted from MR title
+/mr-audit                   # Current branch's MR
+```

--- a/claude/skills/mr-audit/SKILL.md
+++ b/claude/skills/mr-audit/SKILL.md
@@ -7,8 +7,6 @@ description: >-
 argument-hint: [mr-number] [jira-ticket]
 disable-model-invocation: true
 allowed-tools: Bash(codex exec *), Bash(which *), Bash(glab mr view *), Bash(glab mr diff *), Bash(glab mr list *), Bash(git log *), Bash(git diff *), Bash(jj log *), Bash(jj show *), Bash(jq *), Read, Grep, Glob, Skill(mr-review *), Skill(jira *)
-metadata:
-  compatibility: Requires codex CLI (npm i -g @openai/codex), glab CLI, and Codex skills (jira, mr-review) in ~/.codex/skills/. See references/SETUP.md. Degrades gracefully to Claude-only if Codex is unavailable.
 ---
 
 # Triple-Model MR Review
@@ -179,24 +177,7 @@ This is the core value. Three independent models give three perspectives — ove
 
 ### 3.1 Classify Findings
 
-For each finding, assign two things:
-
-**Consensus tag** — how many sources flagged it:
-
-| Tag | Meaning |
-|-----|---------|
-| `[all]` | All available sources agree |
-| `[2/3]` | Two of three sources agree |
-| `[confirmed]` | Single source, verified by code investigation |
-| `[uncertain]` | Single source, could not confirm or dismiss |
-
-**Severity** — how bad it is:
-
-| Severity | Use for |
-|----------|---------|
-| **Must Fix** | Bugs, missing safety nets, production breakage |
-| **Should Fix** | Code quality, duplication, maintainability |
-| **Nit** | Style, naming, minor inconsistencies |
+For each finding, assign a **consensus tag** and a **severity** per the definitions in [references/report-format.md](references/report-format.md) (see "Consensus tags" and "Severity groups" tables).
 
 Match findings by: same file + same function/area + same type of issue. Similar issues in the same area count as agreement even if wording differs.
 

--- a/claude/skills/mr-audit/SKILL.md
+++ b/claude/skills/mr-audit/SKILL.md
@@ -13,7 +13,7 @@ allowed-tools: Bash(codex exec *), Bash(which *), Bash(glab mr view *), Bash(gla
 
 Run three independent reviews in parallel — Claude Code (`/mr-review`), Codex skill-based (`$mr-review`), and Codex built-in code review — then cross-validate findings against the codebase and compile a single confidence-tiered report.
 
-> **Critical rule**: Every Bash command must be a standalone call. NEVER combine commands with `||`, `&&`, `|`, or `;`. Handle errors and fallbacks in skill logic — run one command, check its output, then decide what to do next. Compound commands break the permission system and will trigger approval prompts.
+> **Critical rule**: Every Bash tool call must be a standalone command. NEVER combine commands with `||`, `&&`, `|`, or `;`. Handle errors and fallbacks in skill logic — run one command, check its output, then decide what to do next. Compound commands break the permission system and will trigger approval prompts. This rule applies to Bash tool calls only — `!`command`` pre-flight blocks are preprocessing and may use shell operators freely.
 
 > **Language rule**: The entire report must be written in English. All findings, explanations, suggestions, architecture assessments, and questions must be in English. The only exception is direct quotes from source materials (reviewer comments, MR descriptions, Jira tickets) — these may remain in their original language when explicitly quoted.
 
@@ -125,7 +125,7 @@ codex exec review --base {TARGET_BRANCH} --full-auto --json > "/tmp/codex-builti
 jq -rs '[.[] | select(.type=="item.completed" and .item.type=="agent_message") | .item.text] | last // ""' "/tmp/codex-builtin-raw-{PROJECT}-{MR_NUMBER}.jsonl"
 ```
 
-The review text is returned as Bash output — do NOT redirect to a file with `>` (redirects are shell operators that break permission auto-approval). Hold the output for use in Phase 3.
+The review text is returned as Bash output — do NOT redirect Step 2 output to a file with `>`. Hold it for use in Phase 3. (Step 1 intentionally uses `>` for background capture — this will trigger a one-time permission prompt.)
 
 **Note**: These are two separate Bash calls, not a pipe. See the global rule about standalone commands. See [references/codex-review-bug.md](references/codex-review-bug.md) for why `--json` + `jq` is needed instead of `-o`.
 

--- a/claude/skills/mr-audit/references/SETUP.md
+++ b/claude/skills/mr-audit/references/SETUP.md
@@ -41,7 +41,7 @@ Check if installed:
 ls ~/.codex/skills/jira/SKILL.md ~/.codex/skills/mr-review/SKILL.md
 ```
 
-If missing, copy from the dotfiles repo:
+If missing, copy from the dotfiles repo (adjust path to your dotfiles location):
 ```bash
 cp -r ~/Projects/dotfiles/claude/skills/jira ~/.codex/skills/
 cp -r ~/Projects/dotfiles/claude/skills/mr-review ~/.codex/skills/

--- a/claude/skills/mr-audit/references/SETUP.md
+++ b/claude/skills/mr-audit/references/SETUP.md
@@ -1,0 +1,74 @@
+# mr-audit Skill Prerequisites
+
+## Required
+
+### Codex CLI
+
+```bash
+npm install -g @openai/codex
+```
+
+Verify:
+```bash
+codex --version
+```
+
+Log in:
+```bash
+codex login
+```
+
+### glab CLI
+
+GitLab CLI for MR data.
+
+```bash
+brew install glab
+glab auth login
+```
+
+Verify:
+```bash
+glab mr list
+```
+
+### Codex Skills
+
+The mr-audit skill launches Codex with the `$mr-review` skill, which in turn uses `$jira`. Both must be installed in Codex's skill directory.
+
+Check if installed:
+```bash
+ls ~/.codex/skills/jira/SKILL.md ~/.codex/skills/mr-review/SKILL.md
+```
+
+If missing, copy from the dotfiles repo:
+```bash
+cp -r ~/Projects/dotfiles/claude/skills/jira ~/.codex/skills/
+cp -r ~/Projects/dotfiles/claude/skills/mr-review ~/.codex/skills/
+```
+
+Or from the Claude system skills:
+```bash
+cp -r ~/.claude/skills/jira ~/.codex/skills/
+cp -r ~/.claude/skills/mr-review ~/.codex/skills/
+```
+
+**Important**: The Codex versions of these skills are adapted — they don't use Claude-specific features like `!`command`` auto-execution or `$ARGUMENTS`. If copying from Claude skills, the Codex-adapted versions should already exist in `~/.codex/skills/`. If they don't, see the main README for porting instructions.
+
+### Jira Access (optional)
+
+Required if your MRs reference Jira tickets. See the Jira skill's own setup guide:
+- Claude: `~/.claude/skills/jira/references/SETUP.md`
+- Codex: `~/.codex/skills/jira/references/SETUP.md`
+
+## Graceful Degradation
+
+The skill works without Codex — it degrades to Claude-Only mode automatically. You'll see a note at the top of the report indicating which sources were used.
+
+| Missing Component | Effect |
+|-------------------|--------|
+| Codex CLI | Claude-Only mode (no Codex reviews) |
+| Codex `mr-review` skill | Codex skill review skipped, built-in review still runs |
+| Codex `jira` skill | Codex skill review runs but without Jira context |
+| glab CLI | All reviews affected (no MR metadata) |
+| Jira access | Reviews proceed without ticket context |

--- a/claude/skills/mr-audit/references/codex-review-bug.md
+++ b/claude/skills/mr-audit/references/codex-review-bug.md
@@ -1,0 +1,41 @@
+# Codex CLI `exec review` Output Bug
+
+**Status**: Confirmed bug in Codex CLI
+**Tracked**: https://github.com/openai/codex/issues/6432
+
+## Why `codex exec review` produces empty output
+
+`ReviewTask::run()` in the source code unconditionally returns `None`. The exec output processor receives `None` as the final message and prints nothing to stdout. The actual review text is streamed via `AgentMessage` events to stderr only (via `eprintln!`). So `2>/dev/null` kills the only place the text appears.
+
+The `-o` / `--output-last-message` flag also doesn't work — it writes an empty file with a warning "no last agent message".
+
+## Working workarounds
+
+### Option 1 — `--json` + `jq` (cleanest, recommended)
+
+```bash
+codex exec review --base atv_r/erth/master --full-auto --json \
+  | jq -rs '[.[] | select(.type=="item.completed" and .item.type=="agent_message") | .item.text] | last // ""'
+```
+
+This captures the structured JSONL stream and extracts only the last agent message (the final review).
+
+### Option 2 — Capture stderr, discard stdout
+
+```bash
+codex exec review --base atv_r/erth/master --full-auto 2>&1 1>/dev/null
+```
+
+This is messier because stderr also contains progress info, token counts, and other noise mixed in with the review text.
+
+### Option 3 — Capture everything, grep the review out
+
+```bash
+codex exec review --base atv_r/erth/master --full-auto 2>&1 | tee review_raw.txt
+```
+
+Then manually extract what you need from the file.
+
+## Recommendation
+
+The `--json` + `jq` approach from Option 1 is by far the cleanest path until OpenAI fixes the bug. This is what the `mr-audit` skill uses in Phase 1B.

--- a/claude/skills/mr-audit/references/codex-review-bug.md
+++ b/claude/skills/mr-audit/references/codex-review-bug.md
@@ -38,4 +38,4 @@ Then manually extract what you need from the file.
 
 ## Recommendation
 
-The `--json` + `jq` approach from Option 1 is by far the cleanest path until OpenAI fixes the bug. This is what the `mr-audit` skill uses in Phase 1B.
+The `--json` + `jq` approach is the cleanest path until OpenAI fixes the bug. The `mr-audit` skill uses a two-step variant of Option 1 in Phase 1B: Step 1 captures the JSONL stream to a temp file (for background execution), then Step 2 extracts the review text with `jq` after the background task completes.

--- a/claude/skills/mr-audit/references/glab-flags.md
+++ b/claude/skills/mr-audit/references/glab-flags.md
@@ -14,3 +14,11 @@ The `glab mr list` command does NOT have a `--state` flag. Do not guess flags.
 ## Common mistake
 
 The `-s` flag is `--source-branch`, NOT state. Using `-s open` would filter by a branch named "open", not by MR state.
+
+## glab mr view — JSON output
+
+`glab mr view` supports `-F json` (or `--output json`) for structured JSON output. Use this instead of parsing text output. Key fields: `source_branch`, `target_branch`, `title`, `description`, `author.username`.
+
+## glab api — no --jq flag
+
+`glab api` does NOT have a `--jq` flag. To filter JSON from `glab api`, you would need to pipe to `jq` — but piping is forbidden by the global standalone-command rule. Avoid `glab api` entirely; use `glab mr view -F json` instead.

--- a/claude/skills/mr-audit/references/glab-flags.md
+++ b/claude/skills/mr-audit/references/glab-flags.md
@@ -1,0 +1,16 @@
+# glab mr list — correct flags
+
+The `glab mr list` command does NOT have a `--state` flag. Do not guess flags.
+
+## Listing MRs by state
+
+| Command | Result |
+|---------|--------|
+| `glab mr list` | open MRs (default, no flags needed) |
+| `glab mr list --merged` | merged MRs |
+| `glab mr list --closed` | closed MRs |
+| `glab mr list --all` | all MRs regardless of state |
+
+## Common mistake
+
+The `-s` flag is `--source-branch`, NOT state. Using `-s open` would filter by a branch named "open", not by MR state.

--- a/claude/skills/mr-audit/references/report-format.md
+++ b/claude/skills/mr-audit/references/report-format.md
@@ -74,7 +74,7 @@ False positives filtered out during cross-validation. Listed for transparency.
 {Merged view from all sources — do they agree the approach is sound?}
 
 ### Alternatives Mentioned
-| Approach | Pros | Cons | Source |
+| Approach | Pros | Cons | Origin |
 |----------|------|------|--------|
 | MR's approach | ... | ... | All |
 | Alternative A | ... | ... | {who suggested it} |
@@ -143,4 +143,4 @@ Place `[uncertain]` findings at the bottom of the severity group they belong to.
 
 ### Architecture & Testing
 
-Merge all source assessments into unified text. Do not include per-source columns — the findings section already covers specific issues. These sections provide the big picture: is the approach sound, and is the testing adequate.
+Merge all source assessments into unified text. Do not include per-model columns — the findings section already covers specific issues. These sections provide the big picture: is the approach sound, and is the testing adequate.

--- a/claude/skills/mr-audit/references/report-format.md
+++ b/claude/skills/mr-audit/references/report-format.md
@@ -1,0 +1,146 @@
+# Triple-Model Review Report Template
+
+Replace placeholders with actual data. Adapt sections based on available sources.
+
+---
+
+```markdown
+# Triple-Model Review: {MR_TITLE}
+
+**MR**: !{MR_NUMBER} | **Author**: {AUTHOR} | **Branch**: {BRANCH}
+**Jira**: {TICKET} | **Date**: {DATE}
+**Sources**: {Claude + Codex Skill + Codex Built-in | Claude + Codex Skill | Claude-Only (reason)}
+
+---
+
+## At a Glance
+
+| Metric | Value |
+|--------|-------|
+| Recommendation | Approve / Request Changes / Needs Discussion |
+| Must Fix | {count} |
+| Should Fix | {count} |
+| Nit | {count} |
+| Dismissed (false positives) | {count} |
+
+---
+
+## Findings
+
+All findings from all sources, merged into single assessments. Grouped by severity, ordered by priority within each group.
+
+### Must Fix
+
+[{tag}] **{short summary of the problem}**
+`{file}:{lines}`
+`{file}:{lines}`
+{Free-form explanation. As long as needed to convey the issue clearly.
+Merge insights from all sources that flagged this into one coherent description.
+Do not attribute assessments to individual models — write one unified explanation.}
+→ {suggestion}
+
+### Should Fix
+
+[{tag}] **{short summary}**
+`{file}:{lines}`
+{explanation}
+→ {suggestion}
+
+### Nit
+
+[{tag}] **{short summary}**
+`{file}:{lines}`
+{explanation}
+→ {suggestion}
+
+---
+
+## Dismissed Findings
+
+False positives filtered out during cross-validation. Listed for transparency.
+
+| File:Line | Claim | Dismissal Reason |
+|-----------|-------|------------------|
+| `file:123` | {what was claimed} | {why it's not an issue} |
+
+---
+
+## Architecture & Approach
+
+### Problem Summary
+{What this MR solves, from Jira and MR description}
+
+### Approach Assessment
+{Merged view from all sources — do they agree the approach is sound?}
+
+### Alternatives Mentioned
+| Approach | Pros | Cons | Source |
+|----------|------|------|--------|
+| MR's approach | ... | ... | All |
+| Alternative A | ... | ... | {who suggested it} |
+
+---
+
+## Testing Assessment
+
+| Aspect | Assessment |
+|--------|------------|
+| Coverage | {merged assessment from all sources} |
+| Quality | {merged assessment} |
+| Missing tests | {merged list} |
+
+---
+
+## Questions for Author
+1. {question}
+
+---
+
+*Sources: {list active sources}. {N} total findings, {N} dismissed.*
+```
+
+---
+
+## Filling Instructions
+
+### Finding format
+
+Each finding follows this structure:
+1. `[tag] **summary**` — consensus tag + one-line description of the problem
+2. `` `file:lines` `` — each affected file on its own line
+3. Free-form explanation — as long as needed, merged from all sources into one unified text
+4. `→ suggestion` — what to do about it
+
+### Consensus tags
+
+| Tag | Meaning |
+|-----|---------|
+| `[all]` | All available sources agreed on this finding |
+| `[2/3]` | Two of three sources agreed |
+| `[confirmed]` | Only one source flagged it, verified by code investigation |
+| `[uncertain]` | Only one source flagged it, could not confirm or dismiss |
+
+### Severity groups
+
+| Group | Use for |
+|-------|---------|
+| **Must Fix** | Bugs, missing safety nets, things that will break in production |
+| **Should Fix** | Code quality, duplication, maintainability risks |
+| **Nit** | Style, naming, const correctness, minor inconsistencies |
+
+### Merging explanations
+
+Do NOT list per-model assessments (e.g. "Claude: X, Codex: Y"). Write one merged explanation that combines the best insights from all sources. If sources disagree on severity, use the higher one. The consensus tag already tells the reader how many sources agreed — no need to repeat it in the text.
+
+### Uncertain findings
+
+Place `[uncertain]` findings at the bottom of the severity group they belong to. These are worth the reviewer's attention but could not be definitively confirmed.
+
+### Fewer sources
+
+- If only 2 sources available: `[all]` = both agree, no `[2/3]` tier.
+- If Claude-Only: omit consensus tags entirely, omit Dismissed section.
+
+### Architecture & Testing
+
+Merge all source assessments into unified text. Do not include per-source columns — the findings section already covers specific issues. These sections provide the big picture: is the approach sound, and is the testing adequate.


### PR DESCRIPTION
## Summary
- Add triple-model MR review skill that runs Claude Code, Codex skill-based, and Codex built-in reviews in parallel, cross-validates findings, and produces a unified confidence-tiered report
- Include reference docs for report format, glab flags, Codex CLI workaround, and setup
- Fix invalid frontmatter field and deduplicate classification tables

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive setup and workflow documentation for the MR audit skill, covering prerequisites, installation, execution phases, polling/fallback behavior, and example commands.
  * Added a unified Triple-Model Review report template with formatting, merging, consensus tags, and severity guidelines.
  * Documented CLI usage and flags, a known review-output bug with recommended workarounds, and graceful degradation behavior when components are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->