### PR TITLE
fix(mr-audit): suppress codex exec stdout to avoid context pollution

### DIFF
--- a/claude/skills/mr-audit/SKILL.md
+++ b/claude/skills/mr-audit/SKILL.md
@@ -104,7 +104,7 @@ Run with `run_in_background=true`. This uses the `$mr-review` Codex skill which 
 ```bash
 codex exec -s danger-full-access -C "$PWD" \
   -o "/tmp/codex-mr-review-{PROJECT}-{MR_NUMBER}.md" \
-  '$mr-review {MR_NUMBER}'
+  '$mr-review {MR_NUMBER}' > /dev/null 2>&1
 ```
 
 **Important**: Do NOT use `--full-auto` — it overrides sandbox to workspace-write, blocking network access needed for `glab` and Jira.


### PR DESCRIPTION
## Summary
- Redirect `codex exec` stdout to `/dev/null` for skill-based review to prevent ~70KB+ of thinking output from flooding Claude's context window
- Final review output is still captured to file via the `-o` flag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated audit review behavior so the review process runs silently in the background, suppressing standard output and error messages.
  * Minor maintenance to keep review output from appearing in user-facing logs during the Phase 1A review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->