### PR TITLE
feat(wezterm): wsl default, install scripts, config cleanup

### DIFF
--- a/wezterm/install.ps1
+++ b/wezterm/install.ps1
@@ -3,13 +3,18 @@
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $configDir = Join-Path $env:USERPROFILE ".config\wezterm"
 
-New-Item -ItemType Directory -Path $configDir -Force | Out-Null
-Copy-Item (Join-Path $scriptDir "wezterm.lua") (Join-Path $configDir "wezterm.lua") -Force
+New-Item -ItemType Directory -Path $configDir -Force -ErrorAction Stop | Out-Null
+Copy-Item (Join-Path $scriptDir "wezterm.lua") (Join-Path $configDir "wezterm.lua") -Force -ErrorAction Stop
 Write-Host "installed wezterm.lua to $configDir" -ForegroundColor Green
 
-# remove legacy symlink if it exists
+# back up legacy config if it exists
 $legacyPath = Join-Path $env:USERPROFILE ".wezterm.lua"
 if (Test-Path $legacyPath) {
-    Remove-Item $legacyPath -Force
-    Write-Host "removed legacy symlink $legacyPath" -ForegroundColor Green
+    $backup = "$legacyPath.bak"
+    try {
+        Move-Item $legacyPath $backup -Force -ErrorAction Stop
+        Write-Host "backed up $legacyPath to $backup" -ForegroundColor Yellow
+    } catch {
+        Write-Warning "could not back up ${legacyPath}: $($_.Exception.Message)"
+    }
 }

--- a/wezterm/install.ps1
+++ b/wezterm/install.ps1
@@ -1,0 +1,15 @@
+
+# wezterm config install — windows
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$configDir = Join-Path $env:USERPROFILE ".config\wezterm"
+
+New-Item -ItemType Directory -Path $configDir -Force | Out-Null
+Copy-Item (Join-Path $scriptDir "wezterm.lua") (Join-Path $configDir "wezterm.lua") -Force
+Write-Host "installed wezterm.lua to $configDir" -ForegroundColor Green
+
+# remove legacy symlink if it exists
+$legacyPath = Join-Path $env:USERPROFILE ".wezterm.lua"
+if (Test-Path $legacyPath) {
+    Remove-Item $legacyPath -Force
+    Write-Host "removed legacy symlink $legacyPath" -ForegroundColor Green
+}

--- a/wezterm/install.sh
+++ b/wezterm/install.sh
@@ -9,8 +9,8 @@ mkdir -p "$config_dir"
 cp "$script_dir/wezterm.lua" "$config_dir/wezterm.lua"
 echo "installed wezterm.lua to $config_dir"
 
-# remove legacy symlink if it exists
-if [ -L "${HOME}/.wezterm.lua" ]; then
-  rm "${HOME}/.wezterm.lua"
-  echo "removed legacy symlink ~/.wezterm.lua"
+# back up legacy config if it exists
+if [ -e "${HOME}/.wezterm.lua" ] || [ -L "${HOME}/.wezterm.lua" ]; then
+  mv "${HOME}/.wezterm.lua" "${HOME}/.wezterm.lua.bak"
+  echo "backed up ~/.wezterm.lua to ~/.wezterm.lua.bak"
 fi

--- a/wezterm/install.sh
+++ b/wezterm/install.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# wezterm config install — works on macos, linux, and wsl
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+config_dir="${HOME}/.config/wezterm"
+
+mkdir -p "$config_dir"
+cp "$script_dir/wezterm.lua" "$config_dir/wezterm.lua"
+echo "installed wezterm.lua to $config_dir"
+
+# remove legacy symlink if it exists
+if [ -L "${HOME}/.wezterm.lua" ]; then
+  rm "${HOME}/.wezterm.lua"
+  echo "removed legacy symlink ~/.wezterm.lua"
+fi

--- a/wezterm/wezterm.lua
+++ b/wezterm/wezterm.lua
@@ -4,7 +4,7 @@ local act = wezterm.action
 
 -- Set default shell only on Windows; otherwise let WezTerm decide
 if wezterm.target_triple:find("windows") then
-  config.default_prog = { "C:\\Program Files\\PowerShell\\7\\pwsh.exe", "-NoLogo" }
+  config.default_prog = { "wsl.exe", "-d", "Ubuntu" }
 end
 
 config.launch_menu = wezterm.target_triple:find("windows") and {
@@ -172,7 +172,7 @@ local ui_config = {
 	tab = {
 		max_width = 60,
 		use_fancy_tab_bar = false,
-		show_new_tab_button = false,
+		show_new_tab_button = wezterm.target_triple:find("windows") and true or false,
 		switch_to_last_active_when_closing = true,
 	},
 

--- a/wezterm/wezterm.lua
+++ b/wezterm/wezterm.lua
@@ -1,13 +1,14 @@
 local wezterm = require("wezterm")
 local config = wezterm.config_builder()
 local act = wezterm.action
+local is_windows = wezterm.target_triple:find("windows")
 
--- Set default shell only on Windows; otherwise let WezTerm decide
-if wezterm.target_triple:find("windows") then
-  config.default_prog = { "wsl.exe", "-d", "Ubuntu" }
+-- shell
+if is_windows then
+	config.default_prog = { "wsl.exe", "-d", "Ubuntu" }
 end
 
-config.launch_menu = wezterm.target_triple:find("windows") and {
+config.launch_menu = is_windows and {
 	{ label = "PowerShell 7", args = { "C:\\Program Files\\PowerShell\\7\\pwsh.exe", "-NoLogo" } },
 	{ label = "WSL Ubuntu", args = { "wsl.exe", "-d", "Ubuntu" } },
 } or {
@@ -15,41 +16,69 @@ config.launch_menu = wezterm.target_triple:find("windows") and {
 	{ label = "Bash", args = { "/bin/bash", "-l" } },
 }
 
--- font configuration
-local font_config = {
-	family = "JetBrainsMono Nerd Font",
-	weight = "Bold",
-	size = 15,
-	ligatures = { "calt=1", "clig=1", "liga=1", "zero", "ss01" },
-	line_height = 1.1,
+-- font
+config.font = wezterm.font("JetBrainsMono Nerd Font", { weight = "Bold" })
+config.font_size = 15
+config.harfbuzz_features = { "calt=1", "clig=1", "liga=1", "zero", "ss01" }
+config.line_height = 1.1
+
+-- color scheme
+config.color_scheme = "Catppuccin Mocha"
+
+-- cursor
+config.cursor_thickness = 2
+config.default_cursor_style = "SteadyBar"
+
+-- window
+config.window_close_confirmation = "NeverPrompt"
+config.window_decorations = "INTEGRATED_BUTTONS|RESIZE"
+config.window_padding = { left = 8, right = 8, top = 12, bottom = 8 }
+config.adjust_window_size_when_changing_font_size = false
+
+-- tab bar
+config.tab_max_width = 60
+config.use_fancy_tab_bar = false
+config.show_new_tab_button_in_tab_bar = is_windows and true or false
+config.switch_to_last_active_tab_when_closing_tab = true
+
+-- panes
+config.inactive_pane_hsb = { saturation = 1.0, brightness = 0.8 }
+
+-- command palette
+config.command_palette_rows = 7
+config.command_palette_font_size = 15
+config.command_palette_bg_color = "#44382D"
+config.command_palette_fg_color = "#c4a389"
+
+-- bell
+config.audible_bell = "Disabled"
+config.visual_bell = {
+	target = "CursorColor",
+	fade_in_function = "EaseIn",
+	fade_in_duration_ms = 150,
+	fade_out_function = "EaseOut",
+	fade_out_duration_ms = 300,
 }
 
-config.font = wezterm.font(font_config.family, { weight = font_config.weight })
-config.font_size = font_config.size
-config.harfbuzz_features = font_config.ligatures
-config.line_height = font_config.line_height
+-- general
+config.bold_brightens_ansi_colors = "No"
+config.default_cwd = wezterm.home_dir
+config.hyperlink_rules = wezterm.default_hyperlink_rules()
+config.scrollback_lines = 10000
 
--- color scheme configuration
-local color_config = {
-	scheme = "Catppuccin Mocha",
-	-- alternative: "Tokyo Night"
+config.quick_select_patterns = {
+	[[([^:\s]+\.(?:img|zip))]],
 }
 
-config.color_scheme = color_config.scheme
-
--- keybinding configuration
-local keys = {}
-
--- --- Tab Management ---
-local tab_keys = {
+-- keybindings
+config.keys = {
+	-- tab management
 	{ key = "t", mods = "ALT", action = act.SpawnTab("CurrentPaneDomain") },
 	{ key = "w", mods = "ALT|SHIFT", action = act.CloseCurrentTab({ confirm = true }) },
 	{ key = "LeftArrow", mods = "ALT", action = act.ActivateTabRelative(-1) },
 	{ key = "RightArrow", mods = "ALT", action = act.ActivateTabRelative(1) },
-}
 
--- tab by number (Alt+1..9)
-local tab_number_keys = {
+	-- tab by number (alt+1..9)
 	{ key = "1", mods = "ALT", action = act.ActivateTab(0) },
 	{ key = "2", mods = "ALT", action = act.ActivateTab(1) },
 	{ key = "3", mods = "ALT", action = act.ActivateTab(2) },
@@ -59,147 +88,34 @@ local tab_number_keys = {
 	{ key = "7", mods = "ALT", action = act.ActivateTab(6) },
 	{ key = "8", mods = "ALT", action = act.ActivateTab(7) },
 	{ key = "9", mods = "ALT", action = act.ActivateTab(8) },
-}
 
--- --- Pane Management ---
-local pane_keys = {
+	-- pane management
 	{ key = "w", mods = "ALT", action = act.CloseCurrentPane({ confirm = true }) },
 	{ key = "h", mods = "ALT", action = act.ActivatePaneDirection("Left") },
 	{ key = "l", mods = "ALT", action = act.ActivatePaneDirection("Right") },
 	{ key = "k", mods = "ALT", action = act.ActivatePaneDirection("Up") },
 	{ key = "j", mods = "ALT", action = act.ActivatePaneDirection("Down") },
 	{ key = "s", mods = "ALT", action = act.PaneSelect({ mode = "SwapWithActive" }) },
-}
 
--- --- Splits ---
-local split_keys = {
+	-- splits
 	{ key = "H", mods = "ALT", action = act.SplitHorizontal({ domain = "CurrentPaneDomain" }) },
 	{ key = "V", mods = "ALT", action = act.SplitVertical({ domain = "CurrentPaneDomain" }) },
-}
 
--- --- Pane Resizing ---
-local resize_keys = {
+	-- pane resizing
 	{ key = "LeftArrow", mods = "ALT|SHIFT", action = act.AdjustPaneSize({ "Left", 3 }) },
 	{ key = "RightArrow", mods = "ALT|SHIFT", action = act.AdjustPaneSize({ "Right", 3 }) },
 	{ key = "UpArrow", mods = "ALT|SHIFT", action = act.AdjustPaneSize({ "Up", 2 }) },
 	{ key = "DownArrow", mods = "ALT|SHIFT", action = act.AdjustPaneSize({ "Down", 2 }) },
-}
 
--- --- Shell Passthrough ---
--- let ctrl+f and ctrl+r reach the shell for psreadline/psfzf
--- wezterm search is still available via ctrl+shift+f, reload via alt+r
-local passthrough_keys = {
+	-- shell passthrough (ctrl+f and ctrl+r reach the shell for psreadline/fzf)
 	{ key = "f", mods = "CTRL", action = act.SendKey({ key = "f", mods = "CTRL" }) },
 	{ key = "r", mods = "CTRL", action = act.SendKey({ key = "r", mods = "CTRL" }) },
+
+	-- config reload
+	{ key = "r", mods = "ALT", action = act.ReloadConfiguration },
 }
 
--- --- Configuration & Utilities ---
-local config_keys = {
-  { key = "r", mods = "ALT", action = act.ReloadConfiguration },
-}
-
--- combine all keybindings
-for _, group in ipairs({ tab_keys, tab_number_keys, pane_keys, split_keys, resize_keys, passthrough_keys, config_keys }) do
-	for _, key in ipairs(group) do
-		table.insert(keys, key)
-	end
-end
-
-config.keys = keys
-
--- ui configuration
-local ui_config = {
-	-- command palette
-	command_palette = {
-		rows = 7,
-		font_size = 15,
-		bg_color = "#44382D",
-		fg_color = "#c4a389",
-	},
-
-	-- visual bell
-	bell = {
-		audible = "Disabled",
-		visual = {
-			target = "CursorColor",
-			fade_in_function = "EaseIn",
-			fade_in_duration_ms = 150,
-			fade_out_function = "EaseOut",
-			fade_out_duration_ms = 300,
-		},
-	},
-
-	-- cursor and visual settings
-	cursor = {
-		thickness = 2,
-		style = "SteadyBar",
-	},
-
-	-- window settings
-	window = {
-		close_confirmation = "NeverPrompt",
-		decorations = "INTEGRATED_BUTTONS|RESIZE",
-		padding = { left = 8, right = 8, top = 12, bottom = 8 },
-		adjust_size_when_changing_font = false,
-	},
-
-	-- tab settings
-	tab = {
-		max_width = 60,
-		use_fancy_tab_bar = false,
-		show_new_tab_button = wezterm.target_triple:find("windows") and true or false,
-		switch_to_last_active_when_closing = true,
-	},
-
-	-- pane settings
-	pane = {
-		inactive_hsb = { saturation = 1.0, brightness = 0.8 },
-	},
-}
-
--- general settings
-local general_config = {
-	bold_brightens_ansi_colors = "No",
-	default_cwd = wezterm.home_dir,
-	hyperlink_rules = wezterm.default_hyperlink_rules(),
-	scrollback_lines = 10000,
-}
-
--- apply command palette settings
-config.command_palette_rows = ui_config.command_palette.rows
-config.command_palette_font_size = ui_config.command_palette.font_size
-config.command_palette_bg_color = ui_config.command_palette.bg_color
-config.command_palette_fg_color = ui_config.command_palette.fg_color
-
--- apply bell settings
-config.audible_bell = ui_config.bell.audible
-config.visual_bell = ui_config.bell.visual
-
--- apply cursor settings
-config.cursor_thickness = ui_config.cursor.thickness
-config.default_cursor_style = ui_config.cursor.style
-
--- apply window settings
-config.window_close_confirmation = ui_config.window.close_confirmation
-config.window_decorations = ui_config.window.decorations
-config.window_padding = ui_config.window.padding
-config.adjust_window_size_when_changing_font_size = ui_config.window.adjust_size_when_changing_font
-
--- apply tab settings
-config.tab_max_width = ui_config.tab.max_width
-config.use_fancy_tab_bar = ui_config.tab.use_fancy_tab_bar
-config.show_new_tab_button_in_tab_bar = ui_config.tab.show_new_tab_button
-config.switch_to_last_active_tab_when_closing_tab = ui_config.tab.switch_to_last_active_when_closing
-
--- apply pane settings
-config.inactive_pane_hsb = ui_config.pane.inactive_hsb
-
--- apply general settings
-config.bold_brightens_ansi_colors = general_config.bold_brightens_ansi_colors
-config.default_cwd = general_config.default_cwd
-config.hyperlink_rules = general_config.hyperlink_rules
-config.scrollback_lines = general_config.scrollback_lines
-
+-- tab/window title: show current working directory
 local function get_current_working_dir(tab)
 	local current_dir_uri = tab.active_pane and tab.active_pane.current_working_dir or ""
 	local function normalize_path(p)
@@ -208,16 +124,16 @@ local function get_current_working_dir(tab)
 		return string.lower(p)
 	end
 	local current_dir_path = normalize_path(current_dir_uri:gsub("file://", ""))
-	local home_dir_path = normalize_path((wezterm.target_triple:find("windows") and os.getenv("USERPROFILE")) or os.getenv("HOME") or wezterm.home_dir)
+	local home_dir_path = normalize_path(
+		(is_windows and os.getenv("USERPROFILE")) or os.getenv("HOME") or wezterm.home_dir
+	)
 	if current_dir_path == home_dir_path then
 		return "."
 	end
 	return string.gsub(current_dir_path, "(.*[/\\])(.*)", "%2")
 end
 
--- Set tab title to the one that was set via `tab:set_title()`
--- or fall back to the current working directory as a title
-wezterm.on("format-tab-title", function(tab, tabs, panes, config, hover, max_width)
+wezterm.on("format-tab-title", function(tab)
 	local index = tonumber(tab.tab_index) + 1
 	local custom_title = tab.tab_title
 	local title = get_current_working_dir(tab)
@@ -229,14 +145,8 @@ wezterm.on("format-tab-title", function(tab, tabs, panes, config, hover, max_wid
 	return string.format("  %s•%s  ", index, title)
 end)
 
--- Set window title to the current working directory
-wezterm.on("format-window-title", function(tab, pane, tabs, panes, config)
+wezterm.on("format-window-title", function(tab)
 	return get_current_working_dir(tab)
 end)
-
-config.quick_select_patterns = {
-	-- select firmware files
-	[[([^:\s]+\.(?:img|zip))]],
-}
 
 return config

--- a/wezterm/wezterm.lua
+++ b/wezterm/wezterm.lua
@@ -96,31 +96,6 @@ local passthrough_keys = {
 -- --- Configuration & Utilities ---
 local config_keys = {
   { key = "r", mods = "ALT", action = act.ReloadConfiguration },
-  {
-    key = ",",
-    mods = "CTRL",
-    action = wezterm.action.SpawnCommandInNewTab({
-      cwd = os.getenv("WEZTERM_CONFIG_DIR"),
-      set_environment_variables = {
-        TERM = "screen-256color",
-      },
-      -- Prefer neovide; fallback to nvim or vim if unavailable
-      args = (function()
-        if wezterm.target_triple:find("windows") then
-          local ps = [[
-$cfg = $env:WEZTERM_CONFIG_FILE
-if (Get-Command neovide -ErrorAction SilentlyContinue) { neovide $cfg }
-elseif (Get-Command nvim -ErrorAction SilentlyContinue) { nvim $cfg }
-elseif (Get-Command vim -ErrorAction SilentlyContinue) { vim $cfg }
-else { Write-Host 'No editor (neovide/nvim/vim) found in PATH'; Start-Sleep -Seconds 3 }
-]]
-          return { "powershell.exe", "-NoLogo", "-NoProfile", "-Command", ps }
-        else
-          return { "/bin/sh", "-lc", "neovide \"$WEZTERM_CONFIG_FILE\" || nvim \"$WEZTERM_CONFIG_FILE\" || vim \"$WEZTERM_CONFIG_FILE\"" }
-        end
-      end)(),
-    }),
-  },
 }
 
 -- combine all keybindings

--- a/wezterm/wezterm.lua
+++ b/wezterm/wezterm.lua
@@ -111,42 +111,24 @@ config.keys = {
 	{ key = "f", mods = "CTRL", action = act.SendKey({ key = "f", mods = "CTRL" }) },
 	{ key = "r", mods = "CTRL", action = act.SendKey({ key = "r", mods = "CTRL" }) },
 
+	-- rename tab
+	{ key = "n", mods = "ALT", action = act.PromptInputLine({
+		description = "tab name:",
+		action = wezterm.action_callback(function(window, pane, line)
+			if line then window:active_tab():set_title(line) end
+		end),
+	})},
+
 	-- config reload
 	{ key = "r", mods = "ALT", action = act.ReloadConfiguration },
 }
 
--- tab/window title: show current working directory
-local function get_current_working_dir(tab)
-	local current_dir_uri = tab.active_pane and tab.active_pane.current_working_dir or ""
-	local function normalize_path(p)
-		if not p then return "" end
-		p = p:gsub("\\", "/")
-		return string.lower(p)
-	end
-	local current_dir_path = normalize_path(current_dir_uri:gsub("file://", ""))
-	local home_dir_path = normalize_path(
-		(is_windows and os.getenv("USERPROFILE")) or os.getenv("HOME") or wezterm.home_dir
-	)
-	if current_dir_path == home_dir_path then
-		return "."
-	end
-	return string.gsub(current_dir_path, "(.*[/\\])(.*)", "%2")
-end
-
+-- tab title: show index and custom name if set
 wezterm.on("format-tab-title", function(tab)
 	local index = tonumber(tab.tab_index) + 1
-	local custom_title = tab.tab_title
-	local title = get_current_working_dir(tab)
-
-	if custom_title and #custom_title > 0 then
-		title = custom_title
-	end
-
+	local title = tab.tab_title
+	if not title or #title == 0 then return end
 	return string.format("  %s•%s  ", index, title)
-end)
-
-wezterm.on("format-window-title", function(tab)
-	return get_current_working_dir(tab)
 end)
 
 return config


### PR DESCRIPTION
## Summary
- Set WSL Ubuntu as default shell on Windows, keep PowerShell in launch menu
- Show launcher button ("+") in tab bar on Windows only
- Remove Ctrl+, editor shortcut (broken in WSL context)
- Add install scripts for Windows (`install.ps1`) and Unix (`install.sh`)
- Flatten config: remove intermediate Lua tables, assign directly to `config.*` (267 → 152 lines)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added one-step installers for Windows and Unix/Mac to streamline setup.
  * New keybinding: Alt+N to rename the active tab.

* **Refactor**
  * Simplified configuration and tab-bar behavior.
  * Changed Windows default shell to use WSL Ubuntu.
  * Removed the previous Ctrl+, shortcut and custom window-title computation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->